### PR TITLE
pass page size and record count to pagination component

### DIFF
--- a/src/ReduxTable.js
+++ b/src/ReduxTable.js
@@ -160,6 +160,8 @@ export default class ReduxTable extends React.Component {
       <Pagination
         goToPage={this.onPageChange}
         currentPage={currentPage}
+        pageSize={pageSize}
+        recordCount={sortedData.length}
         />
     );
 


### PR DESCRIPTION
useful for making google-search-result like pagination to have total record count and page size

e.g.: 1 .. 23  *24* 25 .. 39